### PR TITLE
delay initialization of config until it is first referenced.

### DIFF
--- a/src/main/java/moriyashiine/enchancement/common/ModConfig.java
+++ b/src/main/java/moriyashiine/enchancement/common/ModConfig.java
@@ -78,4 +78,8 @@ public class ModConfig extends MidnightConfig {
 		}
 		return allowedEnchantments.contains(identifier.toString());
 	}
+
+	static {
+		MidnightConfig.init(Enchancement.MOD_ID, ModConfig.class);
+	}
 }

--- a/src/main/java/moriyashiine/enchancement/common/ModPreLaunchEntrypoint.java
+++ b/src/main/java/moriyashiine/enchancement/common/ModPreLaunchEntrypoint.java
@@ -5,13 +5,11 @@
 package moriyashiine.enchancement.common;
 
 import com.llamalad7.mixinextras.MixinExtrasBootstrap;
-import eu.midnightdust.lib.config.MidnightConfig;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 public class ModPreLaunchEntrypoint implements PreLaunchEntrypoint {
 	@Override
 	public void onPreLaunch() {
 		MixinExtrasBootstrap.init();
-		MidnightConfig.init(Enchancement.MOD_ID, ModConfig.class);
 	}
 }


### PR DESCRIPTION
fixes https://github.com/MoriyaShiine/enchancement/issues/26.
The issue is in fact impossible to fix on Essential's end, and is caused by enchancement loading game classes too early.