### PR TITLE
Make sure EnchantmentDescriptionsEvent doesn't apply twice on the same enchantment.

### DIFF
--- a/src/main/java/moriyashiine/enchancement/client/event/EnchantmentDescriptionsEvent.java
+++ b/src/main/java/moriyashiine/enchancement/client/event/EnchantmentDescriptionsEvent.java
@@ -27,6 +27,7 @@ public class EnchantmentDescriptionsEvent implements ItemTooltipCallback {
 				for (int i = 0; i < lines.size(); i++) {
 					if (lines.get(i).getContent() instanceof TranslatableTextContent text && text.getKey().equals(enchantment.getTranslationKey())) {
 						lines.add(i + 1, Text.literal(" - ").formatted(Formatting.GRAY).append(Text.translatable(enchantment.getTranslationKey() + ".desc").formatted(Formatting.DARK_GRAY)));
+						break;
 					}
 				}
 			});


### PR DESCRIPTION
Tl;dr. This is a single line change that breaks after an enchantment's description has been applied to text. It will then move onto the next enchantment.

Descriptions will only put a description after the first instance, which should be the enchantment's name. This fixes incompatibilities when a tooltip has references of the name after the initial enchantment name, such as if there's trailing information that requires an enchantment's name to be used.

Any mods that display text before the enchantment name should not be doing that, and so this PR does not account for that.