### PR TITLE
Added create sandpapers to retains_durability item tag

### DIFF
--- a/src/main/resources/data/enchancement/tags/items/retains_durability.json
+++ b/src/main/resources/data/enchancement/tags/items/retains_durability.json
@@ -1,13 +1,13 @@
 {
   "replace": false,
   "values": [
-	{
-	  "id": "create:super_glue",
-	  "required": false
-	},
     {
-	  "id": "#create:sandpaper",
-	  "required": false
+      "id": "create:super_glue",
+      "required": false
+    },
+    {
+      "id": "#create:sandpaper",
+      "required": false
     }
   ]
 }

--- a/src/main/resources/data/enchancement/tags/items/retains_durability.json
+++ b/src/main/resources/data/enchancement/tags/items/retains_durability.json
@@ -4,6 +4,10 @@
 	{
 	  "id": "create:super_glue",
 	  "required": false
-	}
+	},
+    {
+	  "id": "#create:sandpaper",
+	  "required": false
+    }
   ]
 }


### PR DESCRIPTION
Added create sandpapers due to them being bugged when used with deployers (sandpaper gets deleted after first use with a deployer)

I also think it should not get its durability removed anyway as super_glue retains it and it serves a similar, non enchantable functionality and could break the create progression.