### PR TITLE
fix(PersistantProjectileEntityMixin): Check if stack is null 

### DIFF
--- a/src/main/java/moriyashiine/enchancement/mixin/vanillachanges/arrowsdroponhit/PersistentProjectileEntityMixin.java
+++ b/src/main/java/moriyashiine/enchancement/mixin/vanillachanges/arrowsdroponhit/PersistentProjectileEntityMixin.java
@@ -49,7 +49,7 @@ public abstract class PersistentProjectileEntityMixin extends ProjectileEntity {
 			}
 			if (entity instanceof LivingEntity living) {
 				ItemStack stack = asItemStack();
-				if (stack.isIn(ItemTags.ARROWS)) {
+				if (stack != null && stack.isIn(ItemTags.ARROWS)) {
 					ItemEntity drop = living.dropStack(stack, 1);
 					if (drop != null) {
 						drop.setOwner(getOwner().getUuid());


### PR DESCRIPTION
before checking if it's in ARROWS.

Other mods may create ProjectileEntities that don't have an ItemStack. This happens with [Paladins & Priests](https://legacy.curseforge.com/minecraft/mc-mods/paladins-and-priests).

Causing the following crash:
> java.lang.NullPointerException: Cannot invoke "net.minecraft.class_1799.method_31573(net.minecraft.class_6862)" because "stack" is null
	at net.minecraft.class_1665.handler$dal000$enchancement$arrowsDropOnHit(class_1665.java:3261)
	at net.minecraft.class_1665.method_7454(class_1665.java:420)
	at elocindev.shield_overhaul.entity.ShieldBashEntity.method_7454(ShieldBashEntity.java:43)
	at net.minecraft.class_1676.method_7488(class_1676.java:153)
	at net.minecraft.class_1665.method_5773(class_1665.java:227)
	at elocindev.shield_overhaul.entity.ShieldBashEntity.method_5773(ShieldBashEntity.java:33)
	at net.minecraft.class_3218.method_18762(class_3218.java:739)
	at net.minecraft.class_1937.method_18472(class_1937.java:480)
	at net.minecraft.class_3218.method_31420(class_3218.java:385)
	at net.minecraft.class_5574.method_31791(class_5574.java:54)
	at net.minecraft.class_3218.method_18765(class_3218.java:353)
	at net.minecraft.server.MinecraftServer.method_3813(MinecraftServer.java:897)
	at net.minecraft.class_3176.method_3813(class_3176.java:283)
	at net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:824)
	at net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:671)
	at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:265)
	at java.base/java.lang.Thread.run(Thread.java:1583)
