### PR TITLE
[PATCH] Fix Compile Warnings & Potential Issues With 'Berserk' Mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     modCompileOnly "maven.modrinth:sodium:${sodium_version}"
     modRuntimeOnly "maven.modrinth:sodium:${sodium_version}"
     implementation "org.joml:joml:1.10.4"
+	implementation "com.demonwav.mcdev:annotations:2.1.0"
     modCompileOnly "maven.modrinth:spectrum:${spectrum_version}"
 
     modRuntimeOnly "com.terraformersmc:modmenu:${mod_menu_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.10
 loader_version=0.15.7
 # Mod Properties
-mod_version=1.20-26
+mod_version=1.20-27
 maven_group=moriyashiine
 archives_base_name=enchancement
 # Dependencies

--- a/src/main/java/moriyashiine/enchancement/mixin/berserk/client/DrawContextMixin.java
+++ b/src/main/java/moriyashiine/enchancement/mixin/berserk/client/DrawContextMixin.java
@@ -16,10 +16,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(DrawContext.class)
 public class DrawContextMixin {
-	@Inject(method = "drawItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;IIII)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;getItemRenderer()Lnet/minecraft/client/render/item/ItemRenderer;", shift = At.Shift.BEFORE, ordinal = 1))
-	private void enchancement$berserk(LivingEntity entity, World world, ItemStack stack, int x, int y, int seed, int z, CallbackInfo ci) {
-		if (entity != null) {
-			EnchancementClientUtil.berserkColor = EnchancementClientUtil.getBerserkColor(entity, stack);
-		}
-	}
+   @Inject(method = "drawItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;IIII)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;getItemRenderer()Lnet/minecraft/client/render/item/ItemRenderer;", shift = At.Shift.BEFORE, ordinal = 1))
+   private void enchancement$berserk(LivingEntity entity, World world, ItemStack stack, int x, int y, int seed, int z, CallbackInfo ci) {
+       if (entity != null) {
+           EnchancementClientUtil.berserkColor = EnchancementClientUtil.getBerserkColor(entity, stack);
+       }
+   }
+
+   @Inject(method = "drawItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;IIII)V", at = @At("TAIL"))
+   private void enchancement$resetColor(LivingEntity entity, World world, ItemStack stack, int x, int y, int seed, int z, CallbackInfo ci) {
+       EnchancementClientUtil.berserkColor = -1; // Reset the 'berserk' effect after drawing the item. - Knewest
+   }
 }

--- a/src/main/java/moriyashiine/enchancement/mixin/berserk/client/ItemEntityRendererMixin.java
+++ b/src/main/java/moriyashiine/enchancement/mixin/berserk/client/ItemEntityRendererMixin.java
@@ -5,20 +5,30 @@
 package moriyashiine.enchancement.mixin.berserk.client;
 
 import moriyashiine.enchancement.client.util.EnchancementClientUtil;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.entity.ItemEntityRenderer;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ItemEntityRenderer.class)
-public class ItemEntityRendererMixin {
-	@Inject(method = "render(Lnet/minecraft/entity/ItemEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/ItemRenderer;renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"))
-	private void enchancement$berserk(ItemEntity itemEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci) {
-		EnchancementClientUtil.berserkColor = EnchancementClientUtil.getBerserkColor(MinecraftClient.getInstance().player, itemEntity.getStack());
-	}
+@Mixin(ItemRenderer.class)
+public class ItemRendererMixin {
+    @Inject(method = "renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;Lnet/minecraft/world/World;III)V", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/item/ItemRenderer;getModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;I)Lnet/minecraft/client/render/model/BakedModel;"))
+    private void enchancement$berserk(LivingEntity entity, ItemStack item, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, World world, int light, int overlay, int seed, CallbackInfo ci) {
+        if (entity != null) {
+            EnchancementClientUtil.berserkColor = EnchancementClientUtil.getBerserkColor(entity, item);
+        }
+    }
+
+    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("TAIL"))
+    private void enchancement$berserk(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+        EnchancementClientUtil.berserkColor = -1; // Reset the 'berserk' effect after rendering the item. - Knewest
+    }
 }


### PR DESCRIPTION
### What was changed?
1. Implemented `com.demonwav.mcdev` within `build.gradle`, this makes the compilation of the mod faster, and the console output cleaner. 

 **Example (1m 57s VS 21s):** 
 
![image](https://github.com/MoriyaShiine/enchancement/assets/94736474/449df228-3bde-4976-a7de-85cc2af2da18)


2. Fixed an error that can occur under certain conditions when the player chooses to put an item with Berserk I or II, it will colour other items, and entities 'berserk'. This was easily resolved by ensuring the 'berserk' mode is reset each time it is referenced, preventing it leaking to other things.

**Example 1 (Before/After):**

![image](https://github.com/MoriyaShiine/enchancement/assets/94736474/d422c0a5-c2c7-4490-a45a-6703d6afd935)
![image](https://github.com/MoriyaShiine/enchancement/assets/94736474/bd64d207-985e-4c95-b221-168583854f33)

**Example 2 (Before/After):**

![image](https://github.com/MoriyaShiine/enchancement/assets/94736474/0dbb1a03-0ce9-4d42-8fa6-30d58d46bd93)
![image](https://github.com/MoriyaShiine/enchancement/assets/94736474/e33b95d0-8921-4aeb-9c92-c0fc7d939f0e)

3. Updated the build version accordingly.