### PR TITLE
Fixed grammar mistake in E-Speed description

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Leggings Enchantments:
 Boots Enchantments:
 * Buoy: Causes you to walk on fluids, descending via sneaking. Holding jump while submerged or [Space] while wet propels you upward. Prevents floating. Grants a speed boost for some time after leaving water.
 * Bouncy: Negates fall damage. Launches you upward upon landing while not sneaking. Sneaking, moving, or bouncing will charge a super jump that can be released by jumping while holding [Space].
-* E-Speed: Sprinting while grounded builds up an E-Meter, increasing your movement speed. Holding [Space] while at full power allows you float.
+* E-Speed: Sprinting while grounded builds up an E-Meter, increasing your movement speed. Holding [Space] while at full power allows you to float.
 * Sticky: Allows sliding down and jumping off walls. Leaves a trail of honey where you walk that slows mobs.
 
 Sword Enchantments:

--- a/src/main/resources/assets/enchancement/lang/en_us.json
+++ b/src/main/resources/assets/enchancement/lang/en_us.json
@@ -83,7 +83,7 @@
   "enchantment.enchancement.bouncy.desc": "Negates fall damage. Launches you upward upon landing while not sneaking. Sneaking, moving, or bouncing will charge a super jump that can be released by jumping while holding [%s].",
   "enchantment.enchancement.bouncy.desc.inverted": "Negates fall damage. Launches you upward upon landing while sneaking. Sneaking, moving, or bouncing will charge a super jump that can be released by jumping while holding [%s].",
   "enchantment.enchancement.e_speed": "E-Speed",
-  "enchantment.enchancement.e_speed.desc": "Sprinting while grounded builds up an E-Meter, increasing your movement speed. Holding [%s] while at full power allows you float.",
+  "enchantment.enchancement.e_speed.desc": "Sprinting while grounded builds up an E-Meter, increasing your movement speed. Holding [%s] while at full power allows you to float.",
   "enchantment.enchancement.sticky": "Sticky",
   "enchantment.enchancement.sticky.desc": "Allows sliding down and jumping off walls. Leaves a trail of honey where you walk that slows mobs.",
   "enchantment.enchancement.berserk": "Berserk",


### PR DESCRIPTION
“Holding [Space] while at full power allows you float.” changed to “Holding [Space] while at full power allows you to float.”

Added the word "to" between "you" and "float".